### PR TITLE
Updated the exit transition of the tiles when a word is selected

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -33,6 +33,7 @@ define('Chart',
         this._layer = this.base.append('g');
 
         _Chart.transform = function(data) {
+
           d3.select('body')
             .on('touchend', function() {
               endSelection();
@@ -66,7 +67,8 @@ define('Chart',
                 'height': tileSize,
                 'width': tileSize,
                 'rx': 15,
-                'ry': 15
+                'ry': 15,
+                'y':0
               });
 
             this.append('text')
@@ -143,14 +145,18 @@ define('Chart',
           })
           .on('exit', function() {
 
-            this.transition()
-              .duration(750)
-              .attr({
-                'transform': function(d) {
-                  return 'translate(' + (xPos(d) - tileSize * 0.5) + ',' + (yPos(d) + (tileSize * 1.5)) + '), rotate( 20 )';
-                }
-              })
-              .style('opacity', 0)
+            this.select('rect.tiles')
+            .transition()
+            .duration(750)
+            .ease('bounce')
+            .attr({
+              'height': 0,
+              'y': tileSize
+             });
+
+            this
+            .transition()
+              .delay(750)
               .remove();
 
             return this;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ requirejs.config({
     }
 });
 requirejs(['d3', 'game', 'Chart', 'path'], function(d3, game, Chart, path) {
+
   var padding = 50;
   var strokeWidth = 5;
   var height = 800;


### PR DESCRIPTION
Instead of the tiles dropping down and disappearing, now they shrink with a bounce ease so it looks like the tiles are being crushed by the tiles that fall on top of them.